### PR TITLE
Add web interface for Replicate API demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
-# test
-api test
+# Replicate Web Demo
+
+This is a minimal Flask application that allows you to upload an image, send it to the Replicate model `black-forest-labs/flux-kontext-pro`, and view the processed result directly in the browser.
+
+## Setup
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run the server:
+
+```bash
+python app.py
+```
+
+Open your browser at [http://localhost:5000](http://localhost:5000) to use the web interface.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,54 @@
+import os
+import io
+import base64
+from flask import Flask, render_template, request, jsonify
+from PIL import Image
+import requests
+import replicate
+
+app = Flask(__name__)
+
+# Replicate API token (hard-coded as requested)
+os.environ["REPLICATE_API_TOKEN"] = "r8_aLads83FscsbQT8nvQtLhdFYiP3qbnf3EzRZ1"
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+@app.route("/process", methods=["POST"])
+def process_image():
+    file = request.files.get("image")
+    prompt = request.form.get("prompt", "Make this a 90s cartoon")
+    if not file:
+        return jsonify({"error": "No image uploaded"}), 400
+
+    # Resize image to reduce payload
+    image = Image.open(file.stream)
+    image.thumbnail((512, 512))
+    buffer = io.BytesIO()
+    image.save(buffer, format="JPEG")
+    buffer.seek(0)
+
+    output = replicate.run(
+        "black-forest-labs/flux-kontext-pro",
+        input={
+            "prompt": prompt,
+            "input_image": buffer,
+            "output_format": "jpg"
+        }
+    )
+
+    if isinstance(output, list):
+        image_url = output[0]
+    else:
+        image_url = output
+
+    resp = requests.get(image_url)
+    if resp.status_code != 200:
+        return jsonify({"error": "Failed to fetch output"}), 500
+
+    encoded = base64.b64encode(resp.content).decode("utf-8")
+    return jsonify({"image": encoded})
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000, debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+flask
+replicate
+pillow
+requests

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html>
+<head>
+  <title>Replicate Image Demo</title>
+</head>
+<body>
+  <h1>Replicate Image Demo</h1>
+  <input type="file" id="imageInput">
+  <input type="text" id="promptInput" placeholder="Prompt" value="Make this a 90s cartoon">
+  <button id="submitBtn">Process</button>
+  <div id="result"></div>
+
+<script>
+document.getElementById('submitBtn').addEventListener('click', async () => {
+    const image = document.getElementById('imageInput').files[0];
+    const prompt = document.getElementById('promptInput').value;
+    if (!image) {
+        alert('Please select an image.');
+        return;
+    }
+    const formData = new FormData();
+    formData.append('image', image);
+    formData.append('prompt', prompt);
+
+    const response = await fetch('/process', {
+        method: 'POST',
+        body: formData
+    });
+    if(!response.ok){
+        alert('Error processing image.');
+        return;
+    }
+    const data = await response.json();
+    const img = new Image();
+    img.src = 'data:image/jpeg;base64,' + data.image;
+    const resultDiv = document.getElementById('result');
+    resultDiv.innerHTML = '';
+    resultDiv.appendChild(img);
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a minimal Flask server (`app.py`) exposing `/process`
- add web page template with file upload and prompt
- include requirements file and update README with run instructions

## Testing
- `pip install -r requirements.txt`
- `python app.py` *(server started)*

------
https://chatgpt.com/codex/tasks/task_e_685613801978832192643d22794e6d90