### PR TITLE
Allow port configuration via ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,11 @@ Run the server:
 ```bash
 python app.py
 ```
+By default the server listens on port `5000`. You can change the port by setting
+the `PORT` environment variable:
 
-Open your browser at [http://localhost:5000](http://localhost:5000) to use the web interface.
+```bash
+PORT=5001 python app.py
+```
+
+Open your browser at [http://localhost:5000](http://localhost:5000) (or your chosen port) to use the web interface.

--- a/app.py
+++ b/app.py
@@ -51,4 +51,5 @@ def process_image():
     return jsonify({"image": encoded})
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=5000, debug=True)
+    port = int(os.environ.get("PORT", 5000))
+    app.run(host="0.0.0.0", port=port, debug=True)


### PR DESCRIPTION
## Summary
- document how to run the server with a custom `PORT` value
- read `PORT` env variable in `app.py`

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6856207943a88321a61d55fb37bdc06e